### PR TITLE
Feature/yearly profit

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,31 @@ A API possui os seguintes endpoints principais:
 ### **Serviço de cálculo de lucro total**:
 - **Endpoint**: `/sales/profit/total`
 - **Método**: `GET`
-- **Query Parameter**:
+- **Query Parameters**:
   - `days`: Número de dias para considerar o cálculo do lucro (padrão: 365).
+  - `product_id`: ID do produto para filtrar as vendas (opcional).
+
+- **Exemplo de chamada**:
+
+  ```http
+  GET /sales?sort_by=profit&sort_order=desc&days=30&skip=0&limit=10
+  ```
+
+  ```json
+    {
+      "items": [
+        {
+          "id": 1,
+          "product_id": 2,
+          "quantity": 5,
+          "total_price": 500.0,
+          "date": "2024-04-25T00:00:00",
+          "profit": 100.0
+        }
+      ],
+      "total": 23
+    }
+  ```
 
 ### Exportação de Dados
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A API possui os seguintes endpoints principais:
 
 - **GET** `/sales` - Lista todas as vendas, incluindo o cálculo de lucro.
   - **Query parameters:**
-    - `sort_by`: `"total_price"` ou `"profit"` (padrão: `"total_price"`)
+    - `sort_by`: `"total_price"` ou `"profit"` ou `"date"` (padrão: `"total_price"`)
     - `sort_order`: `"asc"` ou `"desc"` (padrão: `"asc"`)
     - `days`: Número de dias retroativos para filtrar as vendas (padrão: `365` dias)
     - `skip`: Número de registros para pular (paginação)

--- a/README.md
+++ b/README.md
@@ -140,17 +140,26 @@ A API possui os seguintes endpoints principais:
 
 - **GET** `/sales` - Lista todas as vendas, incluindo o cálculo de lucro.
   - **Query parameters:**
-    - `sort_by`: Campo para ordenação (`total_price` ou `profit`).
-    - `sort_order`: Direção da ordenação (`asc` ou `desc`).
-    - `page`: Número da página (padrão: 1).
-    - `page_size`: Número de itens por página (padrão: 10).
+    - `sort_by`: `"total_price"` ou `"profit"` (padrão: `"total_price"`)
+    - `sort_order`: `"asc"` ou `"desc"` (padrão: `"asc"`)
+    - `days`: Número de dias retroativos para filtrar as vendas (padrão: `365` dias)
+    - `skip`: Número de registros para pular (paginação)
+    - `limit`: Quantidade máxima de registros para retornar
   - **Resposta:**
+  - GET /sales?sort_by=profit&sort_order=desc&days=30&skip=0&limit=10
     ```json
     {
-      "total": 30,
-      "page": 1,
-      "page_size": 10,
-      "items": [...]
+      "items": [
+        {
+          "id": 1,
+          "product_id": 2,
+          "quantity": 5,
+          "total_price": 500.0,
+          "date": "2024-04-25T00:00:00",
+          "profit": 100.0
+        }
+      ],
+      "total": 23
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ A API possui os seguintes endpoints principais:
 - **PUT** `/sales/{sale_id}` - Atualiza uma venda existente.
 - **DELETE** `/sales/{sale_id}` - Deleta uma venda.
 
+### **Serviço de cálculo de lucro total**:
+- **Endpoint**: `/sales/profit/total`
+- **Método**: `GET`
+- **Query Parameter**:
+  - `days`: Número de dias para considerar o cálculo do lucro (padrão: 365).
+
 ### Exportação de Dados
 
 - **GET** `/export/products` - Exporta os produtos para um arquivo CSV.

--- a/app/routers/sales.py
+++ b/app/routers/sales.py
@@ -38,7 +38,7 @@ router = APIRouter(prefix="/sales", tags=["sales"])
 @router.get("", response_model=PaginatedResponse[schemas.SaleWithProfit])
 def get_sales(
     db: Session = Depends(get_db),
-    sort_by: str = Query("total_price", enum=["total_price", "profit"]),
+    sort_by: str = Query("total_price", enum=["total_price", "profit", "date"]),
     sort_order: str = Query("asc", enum=["asc", "desc"]),
     days: int = Query(365, ge=1, description="Número de dias para considerar (padrão: últimos 365 dias)"),
     skip: int = Query(0, ge=0),
@@ -52,6 +52,8 @@ def get_sales(
 
     if sort_by == "profit":
         sales_with_profit.sort(key=lambda x: x.profit, reverse=(sort_order == "desc"))
+    elif sort_by == "date":
+        sales_with_profit.sort(key=lambda x: x.date, reverse=(sort_order == "desc"))
     else:
         sales_with_profit.sort(key=lambda x: x.total_price, reverse=(sort_order == "desc"))
 

--- a/app/routers/sales.py
+++ b/app/routers/sales.py
@@ -4,6 +4,7 @@ from sqlalchemy import asc, desc
 from app.models import models
 from app.schemas import schemas
 from app.utils.profit import calculate_profit
+from app.services.profit_service import calculate_total_profit
 from app.database import get_db
 from app.utils.pagination import paginate
 from app.schemas.schemas import PaginatedResponse
@@ -64,7 +65,14 @@ def get_sales(
         items=items,
         total=total
     )
-
+    
+@router.get("/profit/total")
+def get_total_profit(
+    db: Session = Depends(get_db),
+    days: int = Query(365, ge=1, description="Número de dias para considerar (padrão: últimos 365 dias)")
+):
+    total_profit = calculate_total_profit(db, days)
+    return {"total_profit": total_profit}
 
 @router.post("/", response_model=schemas.Sale)
 def create_sale(sale: schemas.SaleCreate, db: Session = Depends(get_db)):

--- a/app/routers/sales.py
+++ b/app/routers/sales.py
@@ -66,13 +66,23 @@ def get_sales(
         total=total
     )
     
+# @router.get("/profit/total")
+# def get_total_profit(
+#     db: Session = Depends(get_db),
+#     days: int = Query(365, ge=1, description="Número de dias para considerar (padrão: últimos 365 dias)")
+# ):
+#     total_profit = calculate_total_profit(db, days)
+#     return {"total_profit": total_profit}
+
 @router.get("/profit/total")
 def get_total_profit(
     db: Session = Depends(get_db),
-    days: int = Query(365, ge=1, description="Número de dias para considerar (padrão: últimos 365 dias)")
+    days: int = Query(365, ge=1, description="Número de dias para considerar (padrão: últimos 365 dias)"),
+    product_id: int = Query(None, description="ID do produto para filtrar as vendas")
 ):
-    total_profit = calculate_total_profit(db, days)
-    return {"total_profit": total_profit}
+    result = calculate_total_profit(db, days, product_id)
+    return result
+
 
 @router.post("/", response_model=schemas.Sale)
 def create_sale(sale: schemas.SaleCreate, db: Session = Depends(get_db)):

--- a/app/services/profit_service.py
+++ b/app/services/profit_service.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timedelta
+from sqlalchemy.orm import Session
+from app.models import models
+from app.utils.profit import calculate_profit
+
+def calculate_total_profit(db: Session, days: int = 365) -> float:
+    cutoff_date = datetime.utcnow() - timedelta(days=days)
+
+    sales = db.query(models.Sale).filter(models.Sale.date >= cutoff_date).all()
+
+    total_profit = sum(calculate_profit(sale).profit for sale in sales)
+
+    return total_profit

--- a/app/services/profit_service.py
+++ b/app/services/profit_service.py
@@ -1,13 +1,44 @@
+# from datetime import datetime, timedelta
+# from sqlalchemy.orm import Session
+# from app.models import models
+# from app.utils.profit import calculate_profit
+
+# def calculate_total_profit(db: Session, days: int = 365) -> float:
+#     cutoff_date = datetime.utcnow() - timedelta(days=days)
+
+#     sales = db.query(models.Sale).filter(models.Sale.date >= cutoff_date).all()
+
+#     total_profit = sum(calculate_profit(sale).profit for sale in sales)
+
+#     return total_profit
+
 from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
 from app.models import models
 from app.utils.profit import calculate_profit
 
-def calculate_total_profit(db: Session, days: int = 365) -> float:
+def calculate_total_profit(db: Session, days: int = 365, product_id: int = None) -> dict:
     cutoff_date = datetime.utcnow() - timedelta(days=days)
-
-    sales = db.query(models.Sale).filter(models.Sale.date >= cutoff_date).all()
+    
+    sales_query = db.query(models.Sale).filter(models.Sale.date >= cutoff_date)
+    
+    if product_id:
+        sales_query = sales_query.filter(models.Sale.product_id == product_id)
+    
+    sales = sales_query.all()
 
     total_profit = sum(calculate_profit(sale).profit for sale in sales)
 
-    return total_profit
+    return {
+        "total_profit": total_profit,
+        "sales": [
+            {
+                "product_id": sale.product_id,
+                "quantity": sale.quantity,
+                "total_price": sale.total_price,
+                "date": sale.date,
+                "profit": calculate_profit(sale).profit
+            }
+            for sale in sales
+        ]
+    }


### PR DESCRIPTION
## 📦 Changelog

### **Novas funcionalidades**

- **Cálculo de lucro total por produto**:
  - Adicionado o filtro por `product_id` para o cálculo de lucro total de um produto específico dentro de um intervalo de tempo.
  - O endpoint agora pode retornar tanto o lucro total quanto as vendas correspondentes a um produto dentro do período especificado.

### **Exemplo de uso**

- **Endpoint**: `/sales/profit/total`
- **Método**: `GET`
- **Query Parameters**:
  - `days`: Número de dias para considerar o cálculo do lucro (padrão: 365).
  - `product_id`: ID do produto para filtrar as vendas (opcional).
  
  **Exemplo de chamada**:

  ```http
  GET /sales/profit/total?days=30&product_id=12