### PR TITLE
feat(profit): adicionar nome do produto ao cálculo de lucro total por produto

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ A API possui os seguintes endpoints principais:
 - **Exemplo de chamada**:
 
   ```http
-  GET /sales/profit/total?days=365&product_id=1
+  GET /sales/profit/total?days=30&product_id=12
   ```
 
   ```json

--- a/README.md
+++ b/README.md
@@ -330,38 +330,41 @@ A API possui os seguintes endpoints principais:
 
   ```json
     {
-      "total_profit": 11699.91,
+      "total_profit": 2750.846,
+      "days": 30,
+      "name": "Produto Exemplo",  
       "sales": [
         {
-          "product_id": 1,
-          "quantity": 12,
-          "total_price": 15599.88,
-          "date": "2025-01-15T00:00:00",
-          "profit": 3119.976
+          "product_id": 12,
+          "quantity": 13,
+          "total_price": 2079.87,
+          "date": "2025-09-08T00:00:00",
+          "profit": 415.974
         },
         {
-          "product_id": 1,
-          "quantity": 8,
-          "total_price": 10399.92,
-          "date": "2025-03-22T00:00:00",
-          "profit": 2079.984
-        },
-        {
-          "product_id": 1,
+          "product_id": 12,
           "quantity": 15,
-          "total_price": 19499.85,
-          "date": "2025-07-05T00:00:00",
-          "profit": 3899.97
+          "total_price": 2399.85,
+          "date": "2025-03-15T00:00:00",
+          "profit": 479.97
         },
         {
-          "product_id": 1,
-          "quantity": 10,
-          "total_price": 12999.9,
-          "date": "2025-10-18T00:00:00",
-          "profit": 2599.98
+          "product_id": 12,
+          "quantity": 18,
+          "total_price": 2879.82,
+          "date": "2025-11-22T00:00:00",
+          "profit": 575.964
+        },
+        {
+          "product_id": 12,
+          "quantity": 22,
+          "total_price": 3519.78,
+          "date": "2025-06-10T00:00:00",
+          "profit": 703.956
         }
       ]
     }
+
   ```
 
   ```http

--- a/app/routers/sales.py
+++ b/app/routers/sales.py
@@ -12,30 +12,6 @@ from datetime import datetime, timedelta
 
 router = APIRouter(prefix="/sales", tags=["sales"])
 
-# @router.get("", response_model=PaginatedResponse[schemas.SaleWithProfit])
-# def get_sales(
-#     db: Session = Depends(get_db),
-#     sort_by: str = Query("total_price", enum=["total_price", "profit"]),
-#     sort_order: str = Query("asc", enum=["asc", "desc"]),
-#     skip: int = Query(0, ge=0),
-#     limit: int = Query(10, ge=1)
-# ):
-#     sales = db.query(models.Sale)
-#     sales = sales.all()
-#     sales_with_profit = [calculate_profit(sale) for sale in sales]
-
-#     if sort_by == "profit":
-#         sales_with_profit.sort(key=lambda x: x.profit, reverse=(sort_order == "desc"))
-#     else:
-#         sales_with_profit.sort(key=lambda x: x.total_price, reverse=(sort_order == "desc"))
-
-#     total = len(sales_with_profit)
-#     items = sales_with_profit[skip:skip+limit]
-
-#     return PaginatedResponse(
-#         items=items,
-#         total=total
-#     )
 @router.get("", response_model=PaginatedResponse[schemas.SaleWithProfit])
 def get_sales(
     db: Session = Depends(get_db),
@@ -66,14 +42,6 @@ def get_sales(
         total=total
     )
     
-# @router.get("/profit/total")
-# def get_total_profit(
-#     db: Session = Depends(get_db),
-#     days: int = Query(365, ge=1, description="Número de dias para considerar (padrão: últimos 365 dias)")
-# ):
-#     total_profit = calculate_total_profit(db, days)
-#     return {"total_profit": total_profit}
-
 @router.get("/profit/total")
 def get_total_profit(
     db: Session = Depends(get_db),

--- a/app/services/profit_service.py
+++ b/app/services/profit_service.py
@@ -3,14 +3,32 @@
 # from app.models import models
 # from app.utils.profit import calculate_profit
 
-# def calculate_total_profit(db: Session, days: int = 365) -> float:
+# def calculate_total_profit(db: Session, days: int = 365, product_id: int = None) -> dict:
 #     cutoff_date = datetime.utcnow() - timedelta(days=days)
-
-#     sales = db.query(models.Sale).filter(models.Sale.date >= cutoff_date).all()
+    
+#     sales_query = db.query(models.Sale).filter(models.Sale.date >= cutoff_date)
+    
+#     if product_id:
+#         sales_query = sales_query.filter(models.Sale.product_id == product_id)
+    
+#     sales = sales_query.all()
 
 #     total_profit = sum(calculate_profit(sale).profit for sale in sales)
 
-#     return total_profit
+#     return {
+#         "total_profit": total_profit,
+#         "days": days,
+#         "sales": [
+#             {
+#                 "product_id": sale.product_id,
+#                 "quantity": sale.quantity,
+#                 "total_price": sale.total_price,
+#                 "date": sale.date,
+#                 "profit": calculate_profit(sale).profit
+#             }
+#             for sale in sales
+#         ]
+#     }
 
 from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
@@ -28,9 +46,17 @@ def calculate_total_profit(db: Session, days: int = 365, product_id: int = None)
     sales = sales_query.all()
 
     total_profit = sum(calculate_profit(sale).profit for sale in sales)
+    
+    product_name = None
+    if product_id:
+        product = db.query(models.Product).filter(models.Product.id == product_id).first()
+        if product:
+            product_name = product.name
 
     return {
         "total_profit": total_profit,
+        "days": days,
+        "name": product_name,  
         "sales": [
             {
                 "product_id": sale.product_id,


### PR DESCRIPTION
## 📦 Changelog

### **Novas funcionalidades**

- **Cálculo de lucro total por produto com nome**:
  - Agora o cálculo de lucro total por produto inclui o nome do produto no retorno da consulta.
  - O nome do produto é buscado a partir do `product_id` e retornado no objeto de resposta.

### **Exemplo de uso**

- **Endpoint**: `/sales/profit/total`
- **Método**: `GET`
- **Query Parameters**:
  - `days`: Número de dias para considerar o cálculo do lucro (padrão: 365).
  - `product_id`: ID do produto para filtrar as vendas (opcional).
  
  **Exemplo de chamada**:

  ```http
  GET /sales/profit/total?days=30&product_id=12
  ```

  ```json
    {
          "total_profit": 2750.846,
          "days": 30,
          "name": "Produto Exemplo",  
          "sales": [
            {
              "product_id": 12,
              "quantity": 13,
              "total_price": 2079.87,
              "date": "2025-09-08T00:00:00",
              "profit": 415.974
            },
            {
              "product_id": 12,
              "quantity": 15,
              "total_price": 2399.85,
              "date": "2025-03-15T00:00:00",
              "profit": 479.97
            },
            {
              "product_id": 12,
              "quantity": 18,
              "total_price": 2879.82,
              "date": "2025-11-22T00:00:00",
              "profit": 575.964
            },
            {
              "product_id": 12,
              "quantity": 22,
              "total_price": 3519.78,
              "date": "2025-06-10T00:00:00",
              "profit": 703.956
            }
          ]
        }
