### PR TITLE
feat(price-history): adicionar funcionalidade de ordenação por data e preço

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.routers import products, categories, sales, export, users
+from app.routers import products, categories, sales, export, users, price_history
 from fastapi.middleware.cors import CORSMiddleware
 
 tags_metadata = [
@@ -14,6 +14,18 @@ tags_metadata = [
     {
         "name": "sales",
         "description": "Operações relacionadas às vendas",
+    },
+    {
+        "name": "export",
+        "description": "Operações relacionadas à exportação de dados",
+    },
+    {
+        "name": "users",
+        "description": "Operações relacionadas à autenticação e gerenciamento de usuários",
+    },
+    {
+        "name": "price-history",
+        "description": "Operações relacionadas à histórico de preços dos produtos",
     },
 ]
 
@@ -36,3 +48,5 @@ app.include_router(categories.router)
 app.include_router(sales.router)
 app.include_router(export.router)
 app.include_router(users.router)
+app.include_router(price_history.router)
+

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -22,7 +22,6 @@ class Product(Base):
     price = Column(Float)
     category_id = Column(Integer, ForeignKey("categories.id"))
     brand = Column(String)
-    # category = relationship("Category")
     category = relationship("Category", back_populates="products")
     price_history = relationship("PriceHistory", back_populates="product")
     

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, Integer, String, Float, ForeignKey, DateTime, Enu
 from sqlalchemy.orm import relationship
 from app.database import Base
 from datetime import datetime
-import enum  # ✅ Corrigido
+import enum  
 
 class Category(Base):
     __tablename__ = "categories"
@@ -11,7 +11,9 @@ class Category(Base):
     description = Column(String)
     price = Column(Float)
     brand = Column(String)
-
+    discount_percentage = Column(Float, default=0.0) 
+    products = relationship("Product", back_populates="category")
+    
 class Product(Base):
     __tablename__ = "products"
     id = Column(Integer, primary_key=True, index=True)
@@ -20,8 +22,10 @@ class Product(Base):
     price = Column(Float)
     category_id = Column(Integer, ForeignKey("categories.id"))
     brand = Column(String)
-    category = relationship("Category")
-
+    # category = relationship("Category")
+    category = relationship("Category", back_populates="products")
+    price_history = relationship("PriceHistory", back_populates="product")
+    
 class Sale(Base):
     __tablename__ = "sales"
     id = Column(Integer, primary_key=True, index=True)
@@ -43,3 +47,14 @@ class User(Base):
     password = Column(String, nullable=False) 
     role = Column(Enum(RoleEnum), default=RoleEnum.viewer)
     created_at = Column(DateTime, default=func.now()) 
+
+class PriceHistory(Base):
+    __tablename__ = 'price_history'
+
+    id = Column(Integer, primary_key=True, index=True)
+    product_id = Column(Integer, ForeignKey('products.id'))
+    price = Column(Float)
+    date = Column(DateTime, default=datetime.utcnow)
+    reason = Column(String)
+
+    product = relationship("Product", back_populates="price_history")

--- a/app/routers/price_history.py
+++ b/app/routers/price_history.py
@@ -3,10 +3,11 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models import models
 from app.schemas import schemas
+from typing import List  
 
 router = APIRouter(prefix="/price-history", tags=["price-history"])
 
-@router.get("/{product_id}", response_model=schemas.PriceHistory)
+@router.get("/{product_id}", response_model=List[schemas.PriceHistory])  
 def get_price_history(product_id: int, db: Session = Depends(get_db)):
     price_history = db.query(models.PriceHistory).filter(models.PriceHistory.product_id == product_id).all()
     if not price_history:

--- a/app/routers/price_history.py
+++ b/app/routers/price_history.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app.models import models
+from app.schemas import schemas
+
+router = APIRouter(prefix="/price-history", tags=["price-history"])
+
+@router.get("/{product_id}", response_model=schemas.PriceHistory)
+def get_price_history(product_id: int, db: Session = Depends(get_db)):
+    price_history = db.query(models.PriceHistory).filter(models.PriceHistory.product_id == product_id).all()
+    if not price_history:
+        raise HTTPException(status_code=404, detail="Histórico de preços não encontrado para o produto")
+    return price_history

--- a/app/routers/price_history.py
+++ b/app/routers/price_history.py
@@ -1,15 +1,34 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
+from sqlalchemy import asc, desc
 from app.database import get_db
 from app.models import models
 from app.schemas import schemas
-from typing import List  
+from typing import List
 
 router = APIRouter(prefix="/price-history", tags=["price-history"])
 
-@router.get("/{product_id}", response_model=List[schemas.PriceHistory])  
-def get_price_history(product_id: int, db: Session = Depends(get_db)):
-    price_history = db.query(models.PriceHistory).filter(models.PriceHistory.product_id == product_id).all()
+@router.get("/{product_id}", response_model=List[schemas.PriceHistory])
+def get_price_history(
+    product_id: int,
+    db: Session = Depends(get_db),
+    sort: str = Query("asc", enum=["asc", "desc"]),
+    sort_by: str = Query("date", enum=["date", "price"])
+):
+    query = db.query(models.PriceHistory).filter(models.PriceHistory.product_id == product_id)
+
+    sort_column_map = {
+        "date": models.PriceHistory.date,
+        "price": models.PriceHistory.price
+    }
+
+    sort_column = sort_column_map.get(sort_by, models.PriceHistory.date)
+
+    query = query.order_by(desc(sort_column) if sort == "desc" else asc(sort_column))
+
+    price_history = query.all()
+    
     if not price_history:
         raise HTTPException(status_code=404, detail="Histórico de preços não encontrado para o produto")
+    
     return price_history

--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -100,3 +100,44 @@ def delete_product(product_id: int, db: Session = Depends(get_db)):
 @router.post("/upload-csv")
 def upload_csv(file: UploadFile, db: Session = Depends(get_db)):
     return csv_importer.import_products_csv(file, db)
+
+# Category Routes
+
+@router.put("/categories/{category_id}/discount")
+def update_category_discount(category_id: int, discount_percentage: float, db: Session = Depends(get_db)):
+    category = db.query(models.Category).filter(models.Category.id == category_id).first()
+    if not category:
+        raise HTTPException(status_code=404, detail="Categoria não encontrada")
+
+    category.discount_percentage = discount_percentage
+
+    update_product_prices(db, category_id)
+
+    db.commit()
+    return {"message": "Desconto atualizado com sucesso"}
+
+def update_product_prices(db: Session, category_id: int):
+    category = db.query(models.Category).filter(models.Category.id == category_id).first()
+    if not category:
+        return None
+
+    products = db.query(models.Product).filter(models.Product.category_id == category_id).all()
+
+    for product in products:
+        discount_amount = product.price * (category.discount_percentage / 100)
+        product.price -= discount_amount
+
+        add_price_history(db, product.id, product.price)
+
+    db.commit()
+
+def add_price_history(db: Session, product_id: int, new_price: float, reason: str = None):
+    price_history = models.PriceHistory(
+        product_id=product_id,
+        price=new_price,
+        reason=reason
+    )
+    db.add(price_history)
+    db.commit()
+    db.refresh(price_history)
+    return price_history

--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -99,19 +99,6 @@ def delete_product(product_id: int, db: Session = Depends(get_db)):
 def upload_csv(file: UploadFile, db: Session = Depends(get_db)):
     return csv_importer.import_products_csv(file, db)
 
-# @router.put("/categories/{category_id}/discount")
-# def update_category_discount(category_id: int, discount_percentage: float, db: Session = Depends(get_db)):
-#     category = db.query(models.Category).filter(models.Category.id == category_id).first()
-#     if not category:
-#         raise HTTPException(status_code=404, detail="Categoria não encontrada")
-
-#     category.discount_percentage = discount_percentage
-
-#     update_product_prices(db, category_id)
-
-#     db.commit()
-#     return {"message": "Desconto atualizado com sucesso"}
-
 @router.put("/categories/{category_id}/discount")
 def update_category_discount(
     category_id: int,

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -116,4 +116,4 @@ class PriceHistory(PriceHistoryBase):
     id: int
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -21,6 +21,7 @@ class CategoryBase(BaseModel):
     description: str
     price: float
     brand: str
+    discount_percentage: float
 
 class CategoryCreate(CategoryBase):
     pass
@@ -102,3 +103,17 @@ class LoginRequest(BaseModel):
         if not self.username and not self.email:
             raise ValueError('Você deve fornecer username ou email para login.')
         return self
+    
+# Price History
+
+class PriceHistoryBase(BaseModel):
+    product_id: int
+    price: float
+    date: datetime
+    reason: Optional[str] = None
+
+class PriceHistory(PriceHistoryBase):
+    id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
- Adiciona parâmetros de ordenação `sort` e `sort_by` no endpoint `/price-history/{product_id}`.
- Permite ordenar os históricos de preços por `date` ou `price`, com opções de ordenação crescente (`asc`) ou decrescente (`desc`).
- Implementa mapeamento das colunas para facilitar a ordenação dinâmica.

